### PR TITLE
run custom validate function first, if provided, and update errors ob…

### DIFF
--- a/src/injectGenProps.js
+++ b/src/injectGenProps.js
@@ -50,7 +50,12 @@ const injectGenProps = (FormComponent: ComponentType<*>) => {
 
     validate = (formValues: Object, props: Props) => {
       let errors = {};
-      const {fields, customFieldTypes} = this.props;
+      const {fields, customFieldTypes, validate} = this.props;
+
+      if (validate) {
+        errors = validate(formValues, props);
+      }
+
       // const isFilled = isSectionFilled({
       //   data: formValues,
       //   fields,


### PR DESCRIPTION
**new feature**


### What I did
injectGenProps now looks for a provided `this.props.validate` and runs this before running it's own internal validate function


### How to test
sorta like this:
```
const MyForm = injectGenProps(reduxForm({
  form: 'myForm'
})(InnerFormComponent));

export default (props) => <MyForm  {...props} validate={validate} />;
```

Is this testable with jest?
nyet

Does this need a new example in storybook?
nein

Does this need an update to the documentation?
nope

### PR Checklist
* [ x ] Lint and tests passing (`yarn run check`)
* [ x ] Formatted with prettier (`yarn run format`)
