### PR TITLE
Remove the default export in favor of named exports.

### DIFF
--- a/API.md
+++ b/API.md
@@ -18,7 +18,7 @@
   * [Type: `group`](#type-group)
   * [Type: `section`](#type-section)
 * [API](#api)
-  * [default export `FormGenerator : React.ComponentType<FormGeneratorProps>`](#default-export-formgenerator--reactcomponenttypeformgeneratorprops)
+  * [`FormGenerator : React.ComponentType<FormGeneratorProps>`](#formgenerator--reactcomponenttypeformgeneratorprops)
   * [`isSectionValid: (options: SectionValidOptions) => Object`](#issectionvalid-options-sectionvalidoptions--object)
   * [`isSectionFilled: (options: SectionFilledOptions) => boolean`](#issectionfilled-options-sectionfilledoptions--boolean)
   * [`getDefaultValues: (options: GetDefaultValuesOptions) => Object`](#getdefaultvalues-options-getdefaultvaluesoptions--object)
@@ -142,7 +142,7 @@ Extends [GenericProps](#genericprops). Renders a header for grouping fields.
 
 These are the library exports.
 
-### default export `FormGenerator : React.ComponentType<FormGeneratorProps>`
+### `FormGenerator : React.ComponentType<FormGeneratorProps>`
 
 ### `isSectionValid: (options: SectionValidOptions) => Object`
 

--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ npm install --save @isobar-us/redux-form-gen
 
 ```javascript
 import {reduxForm, Form} from 'redux-form';
-import FormGenerator, {injectGenProps} from '@isobar-us/redux-form-gen';
+import {FormGenerator, injectGenProps} from '@isobar-us/redux-form-gen';
 
 const fields = [
   {
@@ -87,7 +87,7 @@ const MyPage = () => (
 
 ```javascript
 import {reduxForm, Field, Form} from 'redux-form';
-import FormGenerator, {GenericRequiredLabel, injectGenProps} from '@isobar-us/redux-form-gen';
+import {FormGenerator, GenericRequiredLabel, injectGenProps} from '@isobar-us/redux-form-gen';
 
 const SelectField => () => {
   // ... your custom select field implementation

--- a/__tests__/FormGenerator.spec.js
+++ b/__tests__/FormGenerator.spec.js
@@ -7,7 +7,7 @@ import {reduxForm, reducer as formReducer, isDirty, getFormValues} from 'redux-f
 import {createStore, combineReducers} from 'redux';
 import {Provider} from 'react-redux';
 
-import FormGenerator, {getDefaultValues, defaultFieldTypes} from '../src';
+import {FormGenerator, getDefaultValues, defaultFieldTypes} from '../src';
 import RadioField from '../src/defaultFieldTypes/components/RadioField';
 import TextField from '../src/defaultFieldTypes/components/TextField';
 import GenArray from '../src/defaultFieldTypes/components/GenArray';

--- a/__tests__/index.spec.js
+++ b/__tests__/index.spec.js
@@ -1,11 +1,12 @@
-import FormGenerator, * as main from '../src';
+import DefaultExport, * as main from '../src';
 
 describe('index exports', () => {
-  it('should export the correct default export', () => {
-    expect(FormGenerator).toBeDefined();
+  it('should not export a default export', () => {
+    expect(DefaultExport).toBeUndefined();
   });
 
   it('should export the correct named exports', () => {
+    expect(main.FormGenerator).toBeDefined();
     expect(main.defaultFieldTypes).toBeDefined();
     expect(main.getFieldOptions).toBeDefined();
     expect(main.RequiredIndicator).toBeDefined();

--- a/examples/all-fields/src/index.js
+++ b/examples/all-fields/src/index.js
@@ -3,7 +3,7 @@ import {render} from 'react-dom';
 import {createStore, combineReducers} from 'redux';
 import {reducer as formReducer, reduxForm, Form} from 'redux-form';
 import {Provider} from 'react-redux';
-import FormGenerator, {injectGenProps} from '@isobar-us/redux-form-gen';
+import {FormGenerator, injectGenProps} from '@isobar-us/redux-form-gen';
 import '@isobar-us/redux-form-gen/dist/style.css';
 
 const rootReducer = combineReducers({

--- a/examples/basic/src/index.js
+++ b/examples/basic/src/index.js
@@ -3,7 +3,7 @@ import {render} from 'react-dom';
 import {createStore, combineReducers} from 'redux';
 import {reducer as formReducer, reduxForm, Form} from 'redux-form';
 import {Provider} from 'react-redux';
-import FormGenerator, {injectGenProps} from '@isobar-us/redux-form-gen';
+import {FormGenerator, injectGenProps} from '@isobar-us/redux-form-gen';
 import '@isobar-us/redux-form-gen/dist/style.css';
 
 const rootReducer = combineReducers({

--- a/examples/conditional/src/index.js
+++ b/examples/conditional/src/index.js
@@ -3,7 +3,7 @@ import {render} from 'react-dom';
 import {createStore, combineReducers} from 'redux';
 import {reducer as formReducer, reduxForm, Form} from 'redux-form';
 import {Provider} from 'react-redux';
-import FormGenerator, {injectGenProps} from '@isobar-us/redux-form-gen';
+import {FormGenerator, injectGenProps} from '@isobar-us/redux-form-gen';
 import '@isobar-us/redux-form-gen/dist/style.css';
 
 const rootReducer = combineReducers({

--- a/examples/reactstrap/src/index.js
+++ b/examples/reactstrap/src/index.js
@@ -3,7 +3,7 @@ import {render} from 'react-dom';
 import {createStore, combineReducers} from 'redux';
 import {reducer as formReducer, reduxForm} from 'redux-form';
 import {Provider} from 'react-redux';
-import FormGenerator, {injectGenProps} from '@isobar-us/redux-form-gen';
+import {FormGenerator, injectGenProps} from '@isobar-us/redux-form-gen';
 import '@isobar-us/redux-form-gen/dist/style.css';
 import customFieldTypes from './customFieldTypes';
 

--- a/examples/wizard/src/index.js
+++ b/examples/wizard/src/index.js
@@ -3,7 +3,7 @@ import {render} from 'react-dom';
 import {createStore, combineReducers} from 'redux';
 import {reducer as formReducer, reduxForm, Form} from 'redux-form';
 import {Provider} from 'react-redux';
-import FormGenerator, {injectGenProps} from '@isobar-us/redux-form-gen';
+import {FormGenerator, injectGenProps} from '@isobar-us/redux-form-gen';
 import '@isobar-us/redux-form-gen/dist/style.css';
 
 const rootReducer = combineReducers({

--- a/src/index.js
+++ b/src/index.js
@@ -1,6 +1,5 @@
 // @flow
 import FormGenerator from './FormGenerator';
-export default FormGenerator;
 
 import defaultFieldTypes, {getFieldOptions, genericFieldProps} from './defaultFieldTypes';
 import GenericRequiredLabel from './defaultFieldTypes/components/GenericRequiredLabel';
@@ -20,6 +19,8 @@ import GenField from './GenField';
 export type {FieldOptions, CustomFieldTypes} from './types';
 
 export {
+  FormGenerator,
+
   // defaultFieldTypes
   defaultFieldTypes,
   getFieldOptions,


### PR DESCRIPTION
### Are you submitting a **bug fix** or a **new feature**?
⚠️ Breaking Change ⚠️

### What I did
<!-- Include here any detailed explanation, related issues, links, etc. -->
Removed the default export for the `FormGenerator`, and made it a named export.
This is more in-line with other popular libraries, such as `redux-form` and `react-final-form`.

### How to test
<!-- If your answer is yes to any of these, please make sure to include it in your PR. -->

Is this testable with jest?
Yes

Does this need a new example in storybook?
No

Does this need an update to the documentation?
Yes

### PR Checklist
* [x] Update examples
* [x] Update docs
* [x] Lint and tests passing (`yarn run check`)
