### PR TITLE
Isolate wrapper logic into GenWrapper with _genWrapperComponent

### DIFF
--- a/API.md
+++ b/API.md
@@ -68,6 +68,7 @@
     * [`_genFieldComponent?: React.ElementType`](#_genfieldcomponent-reactelementtype)
     * [`_genLabelComponent?: React.ElementType`](#_genlabelcomponent-reactelementtype)
     * [`_genComponent?: React.ElementType`](#_gencomponent-reactelementtype)
+    * [`_genWrapperComponent?: React.ElementType`](#_genwrappercomponent-reactelementtype)
     * [`_genChildren?: FieldsType`](#_genchildren-fieldstype)
     * [`_genDefaultValue?: mixed`](#_gendefaultvalue-mixed)
     * [`_genIsFilled?: Function`](#_genisfilled-function)
@@ -311,6 +312,10 @@ The component to use when rendering the label. Internally uses `GenericRequiredL
 ### `_genComponent?: React.ElementType`
 
 The component to use if you're not rendering a `redux-form` field component (using `_genFieldComponent`)
+
+### `_genWrapperComponent?: React.ElementType`
+
+If provided, it will be passed props from `GenField` as well as the pre-rendered `labelComponent`, `fieldComponent`, and `component`
 
 ### `_genChildren?: FieldsType`
 

--- a/src/GenField.js
+++ b/src/GenField.js
@@ -71,11 +71,6 @@ class GenField extends Component<Props> {
     // Don't render this field or it's children if it's hidden
     if (fieldOptions._genHidden === true) return null;
 
-    const display = has(field, 'display') ? field.display : gen.display;
-    const orientation = {
-      'wrapper--stacked': display === 'stacked',
-      'wrapper--inline': display === 'inline'
-    };
     const isPathVisible = has(gen, 'visibleDepth') ? startsWith(path, gen.visibleDepth) : true;
     if (isNil(path)) {
       console.error('Missing path for ', field);
@@ -102,6 +97,14 @@ class GenField extends Component<Props> {
       !isNil(fieldOptions._genLabelComponent) && React.createElement(fieldOptions._genLabelComponent, this.props);
 
     const component = !isNil(fieldOptions._genComponent) && React.createElement(fieldOptions._genComponent, this.props);
+
+    const wrapperComponent = !isNil(fieldOptions._genWrapperComponent) &&
+      React.createElement(fieldOptions._genWrapperComponent, {
+        ...this.props,
+        labelComponent,
+        fieldComponent,
+        component
+      });
 
     // find `cond` prefixed props automatically
     const condDependentFieldNames = [
@@ -132,20 +135,10 @@ class GenField extends Component<Props> {
           {' '}
           {/* hide if invisible */}
           <div className={cn({'wrapper--hidden-path': !isPathVisible})}>
-            {fieldComponent ? (
-              <div className={cn('wrapper', orientation)}>
-                {labelComponent && labelComponent}
-                {fieldComponent && fieldComponent}
-              </div>
-            ) : labelComponent && component ? (
-              <div className={cn('wrapper', orientation)}>
-                {labelComponent}
-                {component}
-              </div>
-            ) : (
-              // if either the label or component is missing, don't treat as an input-container. just render what you have.
+            {wrapperComponent || (
               <Frag>
                 {labelComponent && labelComponent}
+                {fieldComponent && fieldComponent}
                 {component && component}
               </Frag>
             )}

--- a/src/GenWrapper.js
+++ b/src/GenWrapper.js
@@ -1,0 +1,47 @@
+// @flow
+import React, {Component} from 'react';
+import has from 'lodash/has';
+import cn from 'classnames';
+import {consumeGenContext} from './contextUtils';
+import Frag from './Frag';
+
+import type {Props} from './GenWrapper.types.js';
+
+class GenWrapper extends Component<Props> {
+  render() {
+    const {field, gen, fieldComponent, labelComponent, component} = this.props;
+    const display = has(field, 'display') ? field.display : gen.display;
+    const orientation = {
+      'wrapper--stacked': display === 'stacked',
+      'wrapper--inline': display === 'inline'
+    };
+
+    return (
+      fieldComponent ? (
+        labelComponent ? (
+          <div className={cn('wrapper', orientation)}>
+            {labelComponent}
+            {fieldComponent}
+          </div>
+        ) : (
+          fieldComponent
+        )
+      ) : (
+        labelComponent && component ? (
+          <div className={cn('wrapper', orientation)}>
+            {labelComponent}
+            {component}
+          </div>
+        ) : (
+          // if either the label or component is missing, don't treat as an input-container. just render what you have.
+          <Frag>
+            {labelComponent && labelComponent}
+            {component && component}
+          </Frag>
+        )
+      )
+    );
+  }
+}
+
+export default consumeGenContext(GenWrapper);

--- a/src/GenWrapper.types.js
+++ b/src/GenWrapper.types.js
@@ -1,0 +1,9 @@
+import {Props as GenFieldProps} from './GenField.types';
+import * as React from 'react';
+
+export type Props = {
+  ...GenFieldProps,
+  labelComponent: React.Node,
+  fieldComponent: React.Node,
+  component: React.Node
+};

--- a/src/defaultFieldTypes/defaultFieldOptions.js
+++ b/src/defaultFieldTypes/defaultFieldOptions.js
@@ -1,0 +1,7 @@
+import GenWrapper from '../GenWrapper';
+
+const defaultFieldOptions = {
+  _genWrapperComponent: GenWrapper
+};
+
+export default defaultFieldOptions;

--- a/src/defaultFieldTypes/defaultFieldTypes.js
+++ b/src/defaultFieldTypes/defaultFieldTypes.js
@@ -14,8 +14,10 @@ _genFieldComponent || _genComponent
 
 // const defaultIsFilled = ({data, field}) => !isNilOrEmpty(get(data, field.questionId));
 
+// TODO get rid of _gen prefix, and keep components like FieldComponent and LabelComponent caps to use directly as react components?
 export const genericFieldProps = ({field}) => ({
   _genFieldComponent: Field,
+  // _genWrapperComponent: GenWrapper, // default
   // _genComponent: (props) => { // props are the props passed to GenField
   //   return (<span>Display Component Placeholder</span>);
   // },

--- a/src/defaultFieldTypes/getFieldOptions.js
+++ b/src/defaultFieldTypes/getFieldOptions.js
@@ -1,5 +1,6 @@
 import defaultFieldTypes from './defaultFieldTypes';
 import isNil from 'lodash/isNil';
+import defaultFieldOptions from './defaultFieldOptions';
 
 const getFieldOptions = (options) => {
   const {field, customFieldTypes = {}} = options;
@@ -25,7 +26,10 @@ const getFieldOptions = (options) => {
     );
     return null;
   }
-  return buildFieldOptions(options);
+  return {
+    ...defaultFieldOptions,
+    ...buildFieldOptions(options)
+  };
 };
 
 export default getFieldOptions;

--- a/src/index.js
+++ b/src/index.js
@@ -16,6 +16,7 @@ import {consumeGenContext} from './contextUtils';
 import {evalCond, evalCondValid} from './conditionalUtils';
 
 import GenField from './GenField';
+import GenWrapper from './GenWrapper';
 
 export type {FieldOptions, CustomFieldTypes} from './types';
 
@@ -43,5 +44,6 @@ export {
   evalCond,
   evalCondValid,
   // internals
-  GenField
+  GenField,
+  GenWrapper
 };

--- a/src/types.js
+++ b/src/types.js
@@ -16,6 +16,7 @@ export type FieldsType = Array<FieldType>;
 export type FieldOptions = {
   _genFieldComponent?: React.ElementType,
   _genLabelComponent?: React.ElementType,
+  _genWrapperComponent?: React.ElementType,
   _genComponent?: React.ElementType,
   _genChildren?: FieldsType,
   _genDefaultValue?: mixed,

--- a/stories/allFieldsStructure.js
+++ b/stories/allFieldsStructure.js
@@ -4,11 +4,6 @@ export default [
     label: 'Default Field Types',
     childFields: [
       {
-        type: 'static',
-        label: 'Static Label',
-        text: 'Static Text'
-      },
-      {
         type: 'text',
         questionId: 'text',
         label: 'Text Label',
@@ -67,6 +62,11 @@ export default [
     label: 'Custom Field Types',
     childFields: [
       {
+        type: 'static',
+        label: 'Static Label',
+        text: 'Static Text'
+      },
+      {
         type: 'dateUnknown',
         label: 'Date or Unknown Label',
         required: true,
@@ -82,6 +82,11 @@ export default [
             label: 'Unknown'
           }
         }
+      },
+      {
+        type: 'date',
+        label: 'Date Label',
+        questionId: 'date'
       }
     ]
   }

--- a/stories/index.js
+++ b/stories/index.js
@@ -92,6 +92,11 @@ storiesOf('FormGenerator', module)
       <FormGenerator fields={allFieldsStructure} customFieldTypes={customFieldTypes} />
     </BaseForm>
   ))
+  .add('all field types inline', () => (
+    <BaseForm fields={allFieldsStructure} customFieldTypes={customFieldTypes}>
+      <FormGenerator fields={allFieldsStructure} customFieldTypes={customFieldTypes} display='inline' />
+    </BaseForm>
+  ))
   .add('empty generator', () => (
     <ExampleForm>
       <FormGenerator />


### PR DESCRIPTION
### Are you submitting a **bug fix** or a **new feature**?
🎉 New Feature 🎉

### What I did
<!-- Include here any detailed explanation, related issues, links, etc. -->
* All the logic for stacked/inline rendering of label/field/component components is now isolated in `GenWrapper`. 
* An API for field types has been added to override the `_genWrapperComponent`.
* `defaultFieldOptions` has been added with `_genWrapperComponent: GenWrapper` as the default.
* You can set `_genWrapperComponent: null` to not use any wrapper.

### How to test
<!-- If your answer is yes to any of these, please make sure to include it in your PR. -->

Is this testable with jest?
Yes

Does this need a new example in storybook?
I added an `all fields inline` story to show inline rendering.

Does this need an update to the documentation?
Yes

### PR Checklist
* [x] Update docs
* [x] Lint and tests passing (`yarn run check`)
