### PR TITLE
Rename validate functions for clearer usage.

### DIFF
--- a/API.md
+++ b/API.md
@@ -19,7 +19,7 @@
   * [Type: `section`](#type-section)
 * [API](#api)
   * [default export `FormGenerator : React.ComponentType<FormGeneratorProps>`](#default-export-formgenerator--reactcomponenttypeformgeneratorprops)
-  * [`isSectionValid: (options: SectionValidOptions) => Object`](#issectionvalid-options-sectionvalidoptions--object)
+  * [`getSectionErrors: (options: SectionValidOptions) => Object`](#getsectionerrors-options-sectionvalidoptions--object)
   * [`isSectionFilled: (options: SectionFilledOptions) => boolean`](#issectionfilled-options-sectionfilledoptions--boolean)
   * [`getDefaultValues: (options: GetDefaultValuesOptions) => Object`](#getdefaultvalues-options-getdefaultvaluesoptions--object)
   * [`injectGenProps: (React.ComponentType<ReduxForm>) => React.ComponentType`](#injectgenprops-reactcomponenttypereduxform--reactcomponenttype)
@@ -144,7 +144,7 @@ These are the library exports.
 
 ### default export `FormGenerator : React.ComponentType<FormGeneratorProps>`
 
-### `isSectionValid: (options: SectionValidOptions) => Object`
+### `getSectionErrors: (options: SectionValidOptions) => Object`
 
 ### `isSectionFilled: (options: SectionFilledOptions) => boolean`
 
@@ -153,7 +153,7 @@ These are the library exports.
 ### `injectGenProps: (React.ComponentType<ReduxForm>) => React.ComponentType`
 
 does the heavy lifting to validation, defaultValues, and lookupTable. injects props into a reduxForm decorated component
-(`initialValues`, `validate`) and uses `getDefaultValues` and `isSectionValid`
+(`initialValues`, `validate`) and uses `getDefaultValues` and `getSectionErrors`
 
 ### `buildLookupTable: (options: BuildLookupTableOptions) => LookupTable`
 
@@ -171,7 +171,7 @@ genericFieldProps,
 // validators
 isSectionEmpty,
 isFieldFilled,
-isFieldValid,
+getFieldErrors,
 
 // contextUtils
 consumeGenContext,

--- a/__tests__/conditionalUtils.spec.js
+++ b/__tests__/conditionalUtils.spec.js
@@ -1,8 +1,10 @@
 import {
   evalCond,
-  // evalCondValid,
+  evalCondValid,
   condDependentFields
 } from '../src/conditionalUtils';
+
+import {buildLookupTable} from '../src/utils';
 
 describe('evalCond()', () => {
   describe('shallow/deep', () => {
@@ -697,5 +699,60 @@ describe('condDependentFields()', () => {
     const dependentFields = condDependentFields(cond);
 
     expect(dependentFields).toEqual(['one', 'two', 'three']);
+  });
+});
+
+describe('evalCondValid()', () => {
+  const customFieldTypes = {
+    alwaysError: ({field}) => ({
+      _genIsValid: () => false,
+      name: field.questionId
+    }),
+    alwaysValid: ({field}) => ({
+      _genIsValid: () => true,
+      name: field.questionId
+    })
+  };
+  it('should use getFieldErrors() when no operator is specified', () => {
+    const fields = [
+      {
+        type: 'alwaysError',
+        questionId: 'alwaysError'
+      },
+      {
+        type: 'alwaysValid',
+        questionId: 'alwaysValid'
+      }
+    ];
+
+    const lookupTable = buildLookupTable({
+      fields,
+      customFieldTypes
+    });
+
+    const alwaysError = evalCondValid({
+      cond: {
+        questionId: 'alwaysError'
+      },
+      data: {
+        alwaysError: 'foo'
+      },
+      customFieldTypes,
+      lookupTable
+    });
+
+    const alwaysValid = evalCondValid({
+      cond: {
+        questionId: 'alwaysValid'
+      },
+      data: {
+        alwaysValid: 'foo'
+      },
+      customFieldTypes,
+      lookupTable
+    });
+
+    expect(alwaysError).toBe(false);
+    expect(alwaysValid).toBe(true);
   });
 });

--- a/__tests__/index.spec.js
+++ b/__tests__/index.spec.js
@@ -16,8 +16,8 @@ describe('index exports', () => {
     expect(main.isSectionEmpty).toBeDefined();
     expect(main.isSectionFilled).toBeDefined();
     expect(main.isFieldFilled).toBeDefined();
-    expect(main.isSectionValid).toBeDefined();
-    expect(main.isFieldValid).toBeDefined();
+    expect(main.getSectionErrors).toBeDefined();
+    expect(main.getFieldErrors).toBeDefined();
     expect(main.isNilOrEmpty).toBeDefined();
 
     expect(main.getDefaultValues).toBeDefined();

--- a/__tests__/validators.spec.js
+++ b/__tests__/validators.spec.js
@@ -1,6 +1,6 @@
 import {buildLookupTable} from '../src/utils';
 import exampleFieldTypes from '../stories/customFieldTypes';
-import {isSectionFilled, isSectionValid, REQUIRED_MESSAGE, INVALID_MESSAGE, isNilOrEmpty} from '../src/validators';
+import {isSectionFilled, getSectionErrors, REQUIRED_MESSAGE, INVALID_MESSAGE, isNilOrEmpty} from '../src/validators';
 import get from 'lodash/get';
 
 describe('isSectionFilled()', () => {
@@ -85,7 +85,7 @@ describe('isSectionFilled()', () => {
   });
 });
 
-describe('isSectionValid', () => {
+describe('getSectionErrors', () => {
   const fields = [
     {
       type: 'text',
@@ -187,7 +187,7 @@ describe('isSectionValid', () => {
     };
 
     const lookupTable = buildLookupTable({fields, customFieldTypes: exampleFieldTypes});
-    const errors = isSectionValid({
+    const errors = getSectionErrors({
       fields,
       data,
       customFieldTypes: exampleFieldTypes,
@@ -212,7 +212,7 @@ describe('isSectionValid', () => {
     const customRequiredMessage = 'Custom Required Message';
     const customInvalidMessage = 'Custom Invalid Message';
 
-    const customErrors = isSectionValid({
+    const customErrors = getSectionErrors({
       fields,
       data,
       customFieldTypes: exampleFieldTypes,
@@ -253,7 +253,7 @@ describe('isSectionValid', () => {
     };
 
     const lookupTable = buildLookupTable({fields, customFieldTypes: exampleFieldTypes});
-    const errors = isSectionValid({
+    const errors = getSectionErrors({
       fields,
       data,
       customFieldTypes: exampleFieldTypes,
@@ -302,7 +302,7 @@ describe('isSectionValid', () => {
       const data = {
         check: false
       };
-      const errorsFalse = isSectionValid({
+      const errorsFalse = getSectionErrors({
         fields: checkFields,
         data: data,
         customFieldTypes,
@@ -319,7 +319,7 @@ describe('isSectionValid', () => {
         check: true
       };
 
-      const errors = isSectionValid({
+      const errors = getSectionErrors({
         fields: checkFields,
         data: data,
         customFieldTypes,
@@ -353,7 +353,7 @@ describe('isSectionValid', () => {
       const data = {
         condText: 'something'
       };
-      const errorsFalse = isSectionValid({
+      const errorsFalse = getSectionErrors({
         fields: visFields,
         data: data,
         lookupTable
@@ -367,7 +367,7 @@ describe('isSectionValid', () => {
     it('should show no errors', () => {
       const data = {};
 
-      const errors = isSectionValid({
+      const errors = getSectionErrors({
         fields: visFields,
         data: data,
         lookupTable

--- a/src/conditionalUtils.js
+++ b/src/conditionalUtils.js
@@ -9,7 +9,7 @@ import isEqual from 'lodash/isEqual';
 import isNumber from 'lodash/isNumber';
 import isNil from 'lodash/isNil';
 import isString from 'lodash/isString';
-import {isNilOrEmpty, isFieldValid} from './validators';
+import {isNilOrEmpty, getFieldErrors} from './validators';
 
 import type {FieldType} from './types';
 
@@ -37,7 +37,7 @@ const ops: ConditionalOperators = {
     //   const {cond, data, lookupTable, customFieldTypes} = options;
     //   const field = get(lookupTable, cond.questionId);
     //   // if a dependent field doesn't have required:true, then it will always return true. we force it here.
-    //   return isFieldValid({customFieldTypes, field: {...field, required: true}, data, lookupTable});
+    //   return getFieldErrors({customFieldTypes, field: {...field, required: true}, data, lookupTable});
   },
   includes: ({value, param}) => includes(value, param),
   // comparison
@@ -104,8 +104,18 @@ export const evalCond = (opts: EvalCondOptions) => {
 const condValidElseHandler = (options) => {
   const {cond, data, lookupTable, customFieldTypes} = options;
   const field = get(lookupTable, cond.questionId);
-  // if a dependent field doesn't have required:true, then it will always return true. we force it here.
-  return isFieldValid({customFieldTypes, field: {...field, required: true}, data, lookupTable});
+
+  const fieldErrors = getFieldErrors({
+    customFieldTypes,
+    field: {
+      ...field,
+      required: true // if a dependent field doesn't have required:true, then it will always return true. we force it here.
+    },
+    data,
+    lookupTable
+  });
+
+  return isNilOrEmpty(fieldErrors); // need to check if the errors object is empty. if empty, field is valid.
 };
 export const evalCondValid = (args: EvalCondOptions) =>
   evalCond({

--- a/src/index.js
+++ b/src/index.js
@@ -7,7 +7,14 @@ import GenericRequiredLabel from './defaultFieldTypes/components/GenericRequired
 import RequiredIndicator from './defaultFieldTypes/components/RequiredIndicator';
 import injectGenProps from './injectGenProps';
 
-import {isSectionEmpty, isSectionFilled, isFieldFilled, isSectionValid, isFieldValid, isNilOrEmpty} from './validators';
+import {
+  isSectionEmpty,
+  isSectionFilled,
+  isFieldFilled,
+  getSectionErrors,
+  getFieldErrors,
+  isNilOrEmpty
+} from './validators';
 
 import {getDefaultValues, buildLookupTable} from './utils';
 
@@ -31,8 +38,8 @@ export {
   isSectionEmpty,
   isSectionFilled,
   isFieldFilled,
-  isSectionValid,
-  isFieldValid,
+  getSectionErrors,
+  getFieldErrors,
   isNilOrEmpty,
   // utils
   getDefaultValues,

--- a/src/injectGenProps.js
+++ b/src/injectGenProps.js
@@ -2,7 +2,7 @@
 import React, {Component} from 'react';
 import type {ComponentType} from 'react';
 import PropTypes from 'prop-types';
-import {isSectionValid} from './validators';
+import {getSectionErrors} from './validators';
 import {buildLookupTable, getDefaultValues} from './utils';
 import type {Props, State} from './injectGenProps.types';
 
@@ -63,7 +63,7 @@ const injectGenProps = (FormComponent: ComponentType<*>) => {
       //   lookupTable: this.state.lookupTable
       // });
 
-      isSectionValid({
+      getSectionErrors({
         fields,
         customFieldTypes,
         data: formValues,

--- a/src/validators.js
+++ b/src/validators.js
@@ -34,7 +34,7 @@ import type {
 } from './validators.types';
 
 // options = {fields, data, lookupTable, customFieldTypes, parentQuestionId, errors = {}}
-export const isSectionValid = (options: SectionValidOptions) => {
+export const getSectionErrors = (options: SectionValidOptions) => {
   options = {
     // fields
     // customFieldTypes
@@ -48,7 +48,7 @@ export const isSectionValid = (options: SectionValidOptions) => {
 
   const parentQuestionId = parent && parent.questionId;
 
-  fields.map((field) => isFieldValid({...options, parentQuestionId, field}));
+  fields.map((field) => getFieldErrors({...options, parentQuestionId, field}));
   return errors;
 };
 
@@ -56,7 +56,7 @@ export const INVALID_MESSAGE = 'Invalid Field';
 export const REQUIRED_MESSAGE = 'Required Field';
 
 // options = {field, data, lookupTable, customFieldTypes, parentQuestionId, errors = {}}
-export const isFieldValid = (options: FieldValidOptions) => {
+export const getFieldErrors = (options: FieldValidOptions) => {
   options = {
     // field
     // customFieldTypes
@@ -94,7 +94,7 @@ export const isFieldValid = (options: FieldValidOptions) => {
           ...(parentQuestionId && {valueKey: parentQuestionId})
         })
       ) {
-        isFieldValid({...options, field: omit(field, 'conditionalVisible')});
+        getFieldErrors({...options, field: omit(field, 'conditionalVisible')});
       }
     } else if (visible) {
       const disabled =
@@ -116,6 +116,7 @@ export const isFieldValid = (options: FieldValidOptions) => {
           }));
 
       if (has(fieldOptions, 'name')) {
+        // TODO doesn't work for <Fields names={...} />
         const path = mergePaths(pathPrefix, fieldOptions.name);
         const value = get(data, path);
 
@@ -156,16 +157,16 @@ export const isFieldValid = (options: FieldValidOptions) => {
         // }
       }
       if (has(field, 'childFields') && Array.isArray(field.childFields)) {
-        isSectionValid({...options, parent: field, fields: field.childFields});
+        getSectionErrors({...options, parent: field, fields: field.childFields});
       }
 
       if (fieldOptions._genTraverseChildren) {
         fieldOptions._genTraverseChildren({
           ...options,
-          iterator: isFieldValid
+          iterator: getFieldErrors
         });
       } else if (has(fieldOptions, '_genChildren') && Array.isArray(fieldOptions._genChildren)) {
-        isSectionValid({...options, parent: field, fields: fieldOptions._genChildren});
+        getSectionErrors({...options, parent: field, fields: fieldOptions._genChildren});
       }
     }
   }


### PR DESCRIPTION
### Are you submitting a **bug fix** or a **new feature**?
⚠️ Breaking Change ⚠️

### What I did
<!-- Include here any detailed explanation, related issues, links, etc. -->
This fixes #4 

* Renamed `isSectionValid()` to `getSectionErrors()`
* Renamed `isFieldValid()` to `getFieldErrors()`

This was done in order to make it clearer that `isSectionValid` does not return a boolean, but returns the `errors` object needed for `redux-form`


### How to test
<!-- If your answer is yes to any of these, please make sure to include it in your PR. -->

Is this testable with jest?
Yes

Does this need a new example in storybook?
No

Does this need an update to the documentation?
Yes

### PR Checklist
* [x] Update docs
* [x] Update examples
* [x] Lint and tests passing (`yarn run check`)
