### PR TITLE
fix getDefaultValues for arrays in combination with GenCondClearField

### DIFF
--- a/__tests__/FormGenerator.spec.js
+++ b/__tests__/FormGenerator.spec.js
@@ -268,6 +268,24 @@ describe('<FormGenerator/>', () => {
               type: 'arrayItem',
               childFields: [
                 {
+                  type: 'array',
+                  questionId: 'subArray',
+                  defaultValue: [
+                    {
+                      subArray_item_text: ''
+                    }
+                  ],
+                  item: {
+                    type: 'arrayItem',
+                    childFields: [
+                      {
+                        type: 'text',
+                        questionId: 'subArray_item_text'
+                      }
+                    ]
+                  }
+                },
+                {
                   type: 'radio',
                   label: 'one',
                   questionId: 'array_item_vis',
@@ -425,6 +443,11 @@ describe('<FormGenerator/>', () => {
         four: 'no',
         array: [
           {
+            subArray: [
+              {
+                subArray_item_text: ''
+              }
+            ],
             array_item_text: 'something'
           }
         ]
@@ -451,6 +474,11 @@ describe('<FormGenerator/>', () => {
         four: 'no',
         array: [
           {
+            subArray: [
+              {
+                subArray_item_text: ''
+              }
+            ],
             array_item_text: 'something'
           }
         ]

--- a/__tests__/utils.spec.js
+++ b/__tests__/utils.spec.js
@@ -175,7 +175,6 @@ describe('getDefaultValues()', () => {
     const defaultValues = getDefaultValues({
       fields,
       lookupTable,
-      data: initialValues,
       initialValues
     });
     expect(defaultValues).toEqual({

--- a/src/GenField.js
+++ b/src/GenField.js
@@ -95,7 +95,8 @@ class GenField extends Component<Props> {
         component: GenCondClearField,
         condComponent: options.component,
         visible,
-        _fieldOptions: fieldOptions
+        _fieldOptions: fieldOptions,
+        _field: field
       });
 
     const labelComponent =

--- a/src/defaultFieldTypes/components/GenArray.js
+++ b/src/defaultFieldTypes/components/GenArray.js
@@ -13,7 +13,6 @@ class GenArray extends Component {
     const newItem = getDefaultValues({
       fields: [this.props.item],
       customFieldTypes: this.props.gen.customFieldTypes,
-      data: {},
       initialValues: {}
     });
     return this.props.fields.push(newItem);

--- a/src/injectGenProps.js
+++ b/src/injectGenProps.js
@@ -41,7 +41,6 @@ const injectGenProps = (FormComponent: ComponentType<*>) => {
         initialValues: getDefaultValues({
           fields,
           lookupTable,
-          data: initialValues,
           initialValues,
           customFieldTypes
         })

--- a/src/utils.js
+++ b/src/utils.js
@@ -6,7 +6,12 @@ import compact from 'lodash/compact';
 import {getFieldOptions} from './defaultFieldTypes';
 import defaultsDeep from 'lodash/defaultsDeep';
 
-import type {BuildLookupTableOptions, GetDefaultValuesOptions, GetDefaultValueOptions} from './utils.types';
+import type {
+  BuildLookupTableOptions,
+  GetDefaultValuesOptions,
+  GetDefaultValueOptions,
+  HasDefaultValueOptions
+} from './utils.types';
 
 export const buildLookupTable = (options: BuildLookupTableOptions, table: Object = {}) => {
   const {fields, customFieldTypes} = options;
@@ -80,10 +85,29 @@ export const buildLookupTable = (options: BuildLookupTableOptions, table: Object
   return table;
 };
 
+export const getDefaultValueHelper = ({field, fieldOptions}: HasDefaultValueOptions) => {
+  if (has(field, 'defaultValue')) {
+    return {
+      hasDefaultValue: true,
+      defaultValue: field.defaultValue
+    };
+  } else if (has(fieldOptions, '_genDefaultValue')) {
+    return {
+      hasDefaultValue: true,
+      defaultValue: fieldOptions._genDefaultValue
+    };
+  }
+  return {
+    hasDefaultValue: false,
+    defaultValue: ''
+  };
+};
+
 export const getDefaultValues = (options: GetDefaultValuesOptions) => {
   options = {
     // defaultValues: {},
     ...options,
+    data: options.initialValues || {},
     defaultValues: defaultsDeep(options.defaultValues, options.initialValues)
   };
 
@@ -98,6 +122,7 @@ const getDefaultValue = (options: GetDefaultValueOptions) => {
   options = {
     // defaultValues: {},
     ...options,
+    data: options.initialValues || {},
     defaultValues: defaultsDeep(options.defaultValues, options.initialValues)
   };
 
@@ -115,10 +140,9 @@ const getDefaultValue = (options: GetDefaultValueOptions) => {
       const fieldPath = has(field, 'questionId') ? mergePaths(pathPrefix, field.questionId) : pathPrefix;
       if (has(field, 'questionId') && !has(defaultValues, fieldPath)) {
         // might need isNilOrEmpty(get(defaultValues, fieldPath)) in the future
-        if (has(field, 'defaultValue')) {
-          set(defaultValues, fieldPath, field.defaultValue);
-        } else if (has(fieldOptions, '_genDefaultValue')) {
-          set(defaultValues, fieldPath, fieldOptions._genDefaultValue);
+        const {hasDefaultValue, defaultValue} = getDefaultValueHelper({field, fieldOptions});
+        if (hasDefaultValue) {
+          set(defaultValues, fieldPath, defaultValue);
         }
       }
     }

--- a/src/utils.types.js
+++ b/src/utils.types.js
@@ -1,4 +1,4 @@
-import type {CustomFieldTypes, FieldType, FieldsType} from './types';
+import type {CustomFieldTypes, FieldType, FieldOptions, FieldsType} from './types';
 
 export type BuildLookupTableOptions = {
   fields: FieldsType,
@@ -26,4 +26,9 @@ export type GetDefaultValueOptions = {
 export type GetDefaultValuesOptions = {
   fields: FieldsType,
   ...DefaultOptions
+};
+
+export type HasDefaultValueOptions = {
+  field: FieldType,
+  fieldOptions: FieldOptions
 };


### PR DESCRIPTION
### Are you submitting a **bug fix** or a **new feature**?
🛠 Bug Fix 🛠

### What I did
<!-- Include here any detailed explanation, related issues, links, etc. -->
* Fixed a bug with field.defaultValues for arrays in combination with clear/pristine
* Fixed a bug with getDefaultValues not filling array with defaults if `data` isn't set. Linked `data` to `initialValues` under the hood.
* Unified `hasDefaultValue/defaultValue` logic in `hasDefaultValueHelper()`.
* Fixed bug with `GenCondClearField` not taking into account `field.defaultValue`

### How to test
<!-- If your answer is yes to any of these, please make sure to include it in your PR. -->

Is this testable with jest?
Yes

Does this need a new example in storybook?
No

Does this need an update to the documentation?
No

### PR Checklist
* [x] Lint and tests passing (`yarn run check`)