### PR TITLE
Add _genSkipCache field option to skip clear/restore functionality

### DIFF
--- a/API.md
+++ b/API.md
@@ -391,6 +391,10 @@ Use the provided `iterator` to traverse over complex children.
 
 skip rendering of `childFields`
 
+### `_genSkipCache?: boolean`
+
+skip clearing/restoring the field value when change in visibility happens
+
 ### `_genHidden?: boolean`
 
 skip rendering of this field and all it's children.

--- a/README.md
+++ b/README.md
@@ -217,6 +217,7 @@ Extends `GenericProps`. Renders a header for grouping fields.
 | `_genSectionErrors`                     | func      | `fn({errors, data, field, lookupTable, customFieldTypes}) => void` set in `errors`                    |
 | `_genTraverseChildren`                  | func      | `fn({iterator, data, lookupTable}) => something.map((field) => iterator({field, data, lookupTable}))` |
 | `_genSkipChildren`                      | bool      | skip rendering of `childFields`                                                                       |
+| `_genSkipCache`                         | bool      | skip clear/restore functionality from `FormGenerator` cache                                           |
 | `_genHidden`                            | bool      | skip rendering of this field and all it's children.                                                   |
 | ...                                     | ...       | ...                                                                                                   |
 | any other props for `<Field>` component | any       | `name`, `names`, `component` etc...                                                                   |

--- a/src/GenCondClearField.js
+++ b/src/GenCondClearField.js
@@ -9,9 +9,13 @@ import isEqual from 'lodash/isEqual';
 import type {Props} from './GenCondClearField.types';
 
 class GenCondClearField extends Component<Props> {
-  componentWillReceiveProps(nextProps) {
+  componentWillReceiveProps(nextProps: Props) {
     const {condClearProps: {visible}} = this.props;
-    const {condClearProps: {visible: nextVisible}} = nextProps;
+    const {condClearProps: {visible: nextVisible, fieldOptions}} = nextProps;
+
+    if (fieldOptions._genSkipCache) {
+      return;
+    }
 
     if (has(nextProps, 'input')) {
       if (visible && !nextVisible) {

--- a/src/GenCondClearField.types.js
+++ b/src/GenCondClearField.types.js
@@ -1,5 +1,11 @@
 import type {FieldProps} from 'redux-form';
+import type {FieldOptions, FieldType} from './types';
 
 export type Props = {
-  ...FieldProps
+  ...FieldProps,
+  condClearProps: {
+    fieldOptions: FieldOptions,
+    field: FieldType,
+    visible: boolean
+  }
 };

--- a/src/types.js
+++ b/src/types.js
@@ -27,6 +27,7 @@ export type FieldOptions = {
   _genSectionErrors?: Function,
   _genTraverseChildren?: Function,
   _genSkipChildren?: boolean,
+  _genSkipCache?: boolean,
   _genHidden?: boolean
 };
 

--- a/stories/customFieldTypes/index.js
+++ b/stories/customFieldTypes/index.js
@@ -14,6 +14,7 @@ import dateType from './types/dateType';
 import dateUnknownType from './types/dateUnknownType';
 import staticType from './types/staticType';
 import dividerType from './types/dividerType';
+import persistTextType from './types/persistTextType';
 
 export default {
   columns: columnsType,
@@ -21,6 +22,7 @@ export default {
   dateUnknown: dateUnknownType,
   divider: dividerType,
   checkbox: defaultFieldTypes.text,
+  persistText: persistTextType,
   static: staticType
 };
 

--- a/stories/customFieldTypes/types/persistTextType.js
+++ b/stories/customFieldTypes/types/persistTextType.js
@@ -1,0 +1,8 @@
+import textType from '../../../src/defaultFieldTypes/types/textType';
+
+const persistTextType = (options) => ({
+  ...textType(options),
+  _genSkipCache: true
+});
+
+export default persistTextType;

--- a/stories/index.js
+++ b/stories/index.js
@@ -136,9 +136,9 @@ storiesOf('FormGenerator', module)
   .add('with custom types', () => {
     const exampleStructure = [
       {
-        label: 'bar',
+        label: 'Bar',
         type: 'text',
-        questionId: 'Bar'
+        questionId: 'bar'
       },
       {
         type: 'foo'
@@ -147,9 +147,19 @@ storiesOf('FormGenerator', module)
         type: 'checkbox',
         questionId: 'baz',
         label: 'Baz'
+      },
+      {
+        type: 'persistText',
+        questionId: 'persist',
+        label: 'persist text',
+        conditionalVisible: {
+          questionId: 'bar',
+          equals: 'bar'
+        }
       }
     ];
     const exampleFieldTypes = {
+      ...customFieldTypes,
       checkbox: checkboxType,
       foo: () => ({
         _genComponent: () => <span>A FOO</span>


### PR DESCRIPTION
### Are you submitting a **bug fix** or a **new feature**?
🎉 New Feature 🎉 

### What I did
<!-- Include here any detailed explanation, related issues, links, etc. -->
Added a new field option called `_genSkipCache` which circumvents the clear/restore functionality when any change in visibility happens.

### How to test
<!-- If your answer is yes to any of these, please make sure to include it in your PR. -->

Is this testable with jest?
Yes, but deferring test to later

Does this need a new example in storybook?
Yes

Does this need an update to the documentation?
Yes

### PR Checklist
* [x] Update docs
* [x] Lint and tests passing (`yarn run check`)
* [x] Formatted with prettier (`yarn run format`)
