### PR TITLE
Fixed _genSectionErrors block being unreachable for validation

### DIFF
--- a/src/contextUtils.js
+++ b/src/contextUtils.js
@@ -6,9 +6,7 @@ import createReactContext from 'create-react-context';
 export const GenContext = createReactContext({wasGenerated: false});
 
 export const consumeGenContext = (Component: Function) => (props: mixed) => (
-  <GenContext.Consumer>
-    {(gen) => <Component {...props} gen={gen} /> }
-  </GenContext.Consumer>
+  <GenContext.Consumer>{(gen) => <Component {...props} gen={gen} />}</GenContext.Consumer>
 );
 
 // inspired by

--- a/src/validators.js
+++ b/src/validators.js
@@ -347,11 +347,10 @@ export const getSectionErrorsIterator = (options: FieldValidOptions) => {
         } else if (!isFieldValid(options)) {
           set(errors, path, invalidMessage);
         }
-      } else {
-        // if a field uses `names` then this is how to throw errors
-        if (has(fieldOptions, '_genSectionErrors')) {
-          fieldOptions._genSectionErrors(options);
-        }
+      }
+
+      if (has(fieldOptions, '_genSectionErrors')) {
+        fieldOptions._genSectionErrors(options);
       }
 
       if (deep) {


### PR DESCRIPTION
### Are you submitting a **bug fix** or a **new feature**?
Bug fix

### What I did

- Lifted `_genSectionErrors` from `else` statement to make it reachable. Otherwise section errors might not be correctly thrown during validation.

- Auto-formatted `src/contextUtils.js` with prettier.


### How to test

Is this testable with jest?
**No**


Does this need a new example in storybook?
**No**


Does this need an update to the documentation?
**No**

### PR Checklist
* [x] Lint and tests passing (`yarn run check`)
* [x] Formatted with prettier (`yarn run format`)
