### PR TITLE
Add onSetError event listener to getSectionErrors

### DIFF
--- a/src/validators.js
+++ b/src/validators.js
@@ -347,18 +347,20 @@ export const getSectionErrorsIterator = (options: FieldValidOptions) => {
 
         if (required && !isFieldFilled(options)) {
           set(errors, path, requiredMessage);
-          onSetError && onSetError({
-            type: 'required',
-            path,
-            message: requiredMessage
-          });
+          onSetError &&
+            onSetError({
+              type: 'required',
+              path,
+              message: requiredMessage
+            });
         } else if (!isFieldValid(options)) {
           set(errors, path, invalidMessage);
-          onSetError && onSetError({
-            type: 'invalid',
-            path,
-            message: invalidMessage
-          });
+          onSetError &&
+            onSetError({
+              type: 'invalid',
+              path,
+              message: invalidMessage
+            });
         }
       }
 

--- a/src/validators.js
+++ b/src/validators.js
@@ -292,12 +292,13 @@ export const resolveDisabled = (options: FieldValidatorOptions) => resolve('disa
 // # Valid
 // ####################################################
 
-// options = {fields, data, lookupTable, customFieldTypes, parentQuestionId, errors = {}}
+// options = {fields, data, lookupTable, customFieldTypes, parentQuestionId, onSetError, errors = {}}
 export const getSectionErrors = (options: SectionValidOptions) => {
   options = {
     // fields
     // customFieldTypes
     // data
+    // onSetError
     errors: {},
     deep: true,
     ...options
@@ -329,7 +330,7 @@ export const getSectionErrorsIterator = (options: FieldValidOptions) => {
     fieldOptions: resolveFieldOptions(options)
   };
 
-  const {field, messages, deep, fieldOptions} = options;
+  const {field, messages, deep, fieldOptions, onSetError} = options;
   let {errors} = options;
 
   const requiredMessage = has(field, 'requiredMessage') ? field.requiredMessage : messages.requiredMessage;
@@ -346,8 +347,18 @@ export const getSectionErrorsIterator = (options: FieldValidOptions) => {
 
         if (required && !isFieldFilled(options)) {
           set(errors, path, requiredMessage);
+          onSetError && onSetError({
+            type: 'required',
+            path,
+            message: requiredMessage
+          });
         } else if (!isFieldValid(options)) {
           set(errors, path, invalidMessage);
+          onSetError && onSetError({
+            type: 'invalid',
+            path,
+            message: invalidMessage
+          });
         }
       }
 

--- a/src/validators.types.js
+++ b/src/validators.types.js
@@ -23,6 +23,7 @@ export type FieldValidatorOptions = {
 export type SectionValidOptions = {
   fields: FieldsType,
   errors?: Object,
+  onSetError: Function,
   ...ValidatorOptions
 };
 


### PR DESCRIPTION
### Are you submitting a **bug fix** or a **new feature**?
🎉 New Feature 🎉

### What I did
<!-- Include here any detailed explanation, related issues, links, etc. -->
Added a event listener to know when the `getSectionErrors` function detects an error.

### How to test
<!-- If your answer is yes to any of these, please make sure to include it in your PR. -->

Is this testable with jest?
Yes

Does this need a new example in storybook?
No

Does this need an update to the documentation?
Yes

### PR Checklist
* [x] Lint and tests passing (`yarn run check`)
* [x] Formatted with prettier (`yarn run format`)
