### PR TITLE
Add excludeInvalid and excludeRequired to getSectionErrors

### DIFF
--- a/__tests__/validators.spec.js
+++ b/__tests__/validators.spec.js
@@ -547,6 +547,62 @@ describe('getSectionErrors', () => {
     });
   });
 
+  describe('excludeInvalid / excludeRequired', () => {
+    const visFields = [
+      {
+        type: 'text',
+        questionId: 'requiredText',
+        required: true
+      },
+      {
+        type: 'text',
+        questionId: 'invalidText',
+        conditionalValid: {
+          equals: 'foo'
+        }
+      },
+      {
+        type: 'text',
+        questionId: 'validText'
+      }
+    ];
+
+    const lookupTable = buildLookupTable({fields: visFields});
+
+    it('should exclude invalid errors', () => {
+      const data = {
+        invalidText: 'bar'
+      };
+      const errorsRequired = getSectionErrors({
+        fields: visFields,
+        data: data,
+        lookupTable,
+        excludeInvalid: true
+      });
+
+      expect(errorsRequired).toEqual({
+        requiredText: REQUIRED_MESSAGE
+      });
+    });
+
+    it('should exclude required errors', () => {
+      const data = {
+        invalidText: 'bar'
+      };
+
+      const errorsInvalid = getSectionErrors({
+        fields: visFields,
+        data: data,
+        lookupTable,
+        excludeRequired: true
+      });
+
+      expect(errorsInvalid).toEqual({
+        invalidText: INVALID_MESSAGE
+      });
+    });
+  });
+
   describe('isNilOrEmpty', () => {
     // true
     it('should return true for no param', () => {

--- a/src/validators.js
+++ b/src/validators.js
@@ -299,6 +299,8 @@ export const getSectionErrors = (options: SectionValidOptions) => {
     // customFieldTypes
     // data
     // onSetError
+    excludeInvalid: false,
+    excludeRequired: false,
     errors: {},
     deep: true,
     ...options
@@ -320,6 +322,8 @@ export const getSectionErrorsIterator = (options: FieldValidOptions) => {
     // customFieldTypes
     // data
     // onSetError
+    excludeInvalid: false,
+    excludeRequired: false,
     deep: false,
     errors: {},
     messages: {
@@ -331,7 +335,7 @@ export const getSectionErrorsIterator = (options: FieldValidOptions) => {
     fieldOptions: resolveFieldOptions(options)
   };
 
-  const {field, messages, deep, fieldOptions, onSetError} = options;
+  const {field, messages, deep, fieldOptions, onSetError, excludeInvalid, excludeRequired} = options;
   let {errors} = options;
 
   const requiredMessage = has(field, 'requiredMessage') ? field.requiredMessage : messages.requiredMessage;
@@ -346,7 +350,7 @@ export const getSectionErrorsIterator = (options: FieldValidOptions) => {
       if (has(fieldOptions, 'name')) {
         const path = getFieldPath(options);
 
-        if (required && !isFieldFilled(options)) {
+        if (!excludeRequired && required && !isFieldFilled(options)) {
           set(errors, path, requiredMessage);
           onSetError &&
             onSetError({
@@ -354,7 +358,7 @@ export const getSectionErrorsIterator = (options: FieldValidOptions) => {
               path,
               message: requiredMessage
             });
-        } else if (!isFieldValid(options)) {
+        } else if (!excludeInvalid && !isFieldValid(options)) {
           set(errors, path, invalidMessage);
           onSetError &&
             onSetError({

--- a/src/validators.types.js
+++ b/src/validators.types.js
@@ -24,6 +24,8 @@ export type SectionValidOptions = {
   fields: FieldsType,
   errors?: Object,
   onSetError: Function,
+  excludeInvalid: Boolean,
+  excludeRequired: Boolean,
   ...ValidatorOptions
 };
 
@@ -31,6 +33,8 @@ export type FieldValidOptions = {
   field: FieldType,
   errors?: Object,
   onSetError: Function,
+  excludeInvalid: Boolean,
+  excludeRequired: Boolean,
   ...ValidatorOptions
 };
 


### PR DESCRIPTION
### Are you submitting a **bug fix** or a **new feature**?
🎉 New Feature 🎉

### What I did
<!-- Include here any detailed explanation, related issues, links, etc. -->
You can now pass `excludeRequired` or `excludeInvalid` to `getSectionErrors()` to exclude those errors from showing up in the errors object. 

This useful for the `Save` and `Save and Verify` pattern:
`Save` - allowed when there are no invalid fields.
`Save and Verify` - allowed when there are no invalid fields && all required fields filled.

### How to test
<!-- If your answer is yes to any of these, please make sure to include it in your PR. -->

Is this testable with jest?
Yes

Does this need a new example in storybook?
Maybe

Does this need an update to the documentation?
Yes

### PR Checklist
* [x] Lint and tests passing (`yarn run check`)
* [x] Formatted with prettier (`yarn run format`)
