### PR TITLE
For number comparison operators, return false for nil values

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,5 @@
+{
+  "javascript.validate.enable": false,
+  "flow.useNPMPackagedFlow": true,
+  "editor.formatOnSave": true
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,5 +1,0 @@
-{
-  "javascript.validate.enable": false,
-  "flow.useNPMPackagedFlow": true,
-  "editor.formatOnSave": true
-}

--- a/__tests__/conditionalUtils.spec.js
+++ b/__tests__/conditionalUtils.spec.js
@@ -232,9 +232,9 @@ describe('evalCond()', () => {
       expect(
         evalCond({
           cond: {questionId: 'foo', lessThan: 5},
-          data: {} // nil as 0
+          data: {} // nil will result in false
         })
-      ).toBe(true);
+      ).toBe(false);
     });
 
     it('should return false if foo is not less than 5', () => {
@@ -255,7 +255,7 @@ describe('evalCond()', () => {
       expect(
         evalCond({
           cond: {questionId: 'foo', lessThan: -5},
-          data: {} // nil as 0
+          data: {} // nil will result in false
         })
       ).toBe(false);
     });
@@ -280,9 +280,9 @@ describe('evalCond()', () => {
       expect(
         evalCond({
           cond: {questionId: 'foo', greaterThan: -5},
-          data: {} // nil as 0
+          data: {} // nil will result in false
         })
-      ).toBe(true);
+      ).toBe(false);
     });
 
     it('should return false if foo is not greater than 5', () => {
@@ -303,7 +303,7 @@ describe('evalCond()', () => {
       expect(
         evalCond({
           cond: {questionId: 'foo', greaterThan: 5},
-          data: {} // nil as 0
+          data: {} // nil will result in false
         })
       ).toBe(false);
     });
@@ -328,9 +328,9 @@ describe('evalCond()', () => {
       expect(
         evalCond({
           cond: {questionId: 'foo', lessThanEqual: 5},
-          data: {} // nil as 0
+          data: {} // nil will result in false
         })
-      ).toBe(true);
+      ).toBe(false);
     });
 
     it('should return false if foo is not less than 5', () => {
@@ -351,7 +351,7 @@ describe('evalCond()', () => {
       expect(
         evalCond({
           cond: {questionId: 'foo', lessThanEqual: -5},
-          data: {} // nil as 0
+          data: {} // nil will result in false
         })
       ).toBe(false);
     });
@@ -390,9 +390,9 @@ describe('evalCond()', () => {
       expect(
         evalCond({
           cond: {questionId: 'foo', greaterThanEqual: -5},
-          data: {} // nil as 0
+          data: {} // nil will result in false
         })
-      ).toBe(true);
+      ).toBe(false);
     });
 
     it('should return false if foo is not greater than 5', () => {
@@ -413,7 +413,7 @@ describe('evalCond()', () => {
       expect(
         evalCond({
           cond: {questionId: 'foo', greaterThanEqual: 5},
-          data: {} // nil as 0
+          data: {} // nil will result in false
         })
       ).toBe(false);
     });

--- a/__tests__/conditionalUtils.spec.js
+++ b/__tests__/conditionalUtils.spec.js
@@ -235,6 +235,13 @@ describe('evalCond()', () => {
           data: {} // nil will result in false
         })
       ).toBe(false);
+
+      expect(
+        evalCond({
+          cond: {questionId: 'foo', lessThan: 5},
+          data: {foo: ''} // empty string will result in false
+        })
+      ).toBe(false);
     });
 
     it('should return false if foo is not less than 5', () => {
@@ -256,6 +263,13 @@ describe('evalCond()', () => {
         evalCond({
           cond: {questionId: 'foo', lessThan: -5},
           data: {} // nil will result in false
+        })
+      ).toBe(false);
+
+      expect(
+        evalCond({
+          cond: {questionId: 'foo', lessThan: -5},
+          data: {foo: ''} // empty string will result in false
         })
       ).toBe(false);
     });
@@ -283,6 +297,13 @@ describe('evalCond()', () => {
           data: {} // nil will result in false
         })
       ).toBe(false);
+
+      expect(
+        evalCond({
+          cond: {questionId: 'foo', greaterThan: -5},
+          data: {foo: ''} // empty string will result in false
+        })
+      ).toBe(false);
     });
 
     it('should return false if foo is not greater than 5', () => {
@@ -304,6 +325,13 @@ describe('evalCond()', () => {
         evalCond({
           cond: {questionId: 'foo', greaterThan: 5},
           data: {} // nil will result in false
+        })
+      ).toBe(false);
+
+      expect(
+        evalCond({
+          cond: {questionId: 'foo', greaterThan: 5},
+          data: {foo: ''} // empty string will result in false
         })
       ).toBe(false);
     });
@@ -331,6 +359,13 @@ describe('evalCond()', () => {
           data: {} // nil will result in false
         })
       ).toBe(false);
+
+      expect(
+        evalCond({
+          cond: {questionId: 'foo', lessThanEqual: 5},
+          data: {foo: ''} // empty string will result in false
+        })
+      ).toBe(false);
     });
 
     it('should return false if foo is not less than 5', () => {
@@ -352,6 +387,13 @@ describe('evalCond()', () => {
         evalCond({
           cond: {questionId: 'foo', lessThanEqual: -5},
           data: {} // nil will result in false
+        })
+      ).toBe(false);
+
+      expect(
+        evalCond({
+          cond: {questionId: 'foo', lessThanEqual: -5},
+          data: {foo: ''} // empty string will result in false
         })
       ).toBe(false);
     });
@@ -393,6 +435,13 @@ describe('evalCond()', () => {
           data: {} // nil will result in false
         })
       ).toBe(false);
+
+      expect(
+        evalCond({
+          cond: {questionId: 'foo', greaterThanEqual: -5},
+          data: {foo: ''} // empty string will result in false
+        })
+      ).toBe(false);
     });
 
     it('should return false if foo is not greater than 5', () => {
@@ -414,6 +463,13 @@ describe('evalCond()', () => {
         evalCond({
           cond: {questionId: 'foo', greaterThanEqual: 5},
           data: {} // nil will result in false
+        })
+      ).toBe(false);
+
+      expect(
+        evalCond({
+          cond: {questionId: 'foo', greaterThanEqual: 5},
+          data: {foo: ''} // empty string will result in false
         })
       ).toBe(false);
     });

--- a/src/conditionalUtils.js
+++ b/src/conditionalUtils.js
@@ -33,6 +33,8 @@ const getOperator = (options, key) => {
   return op;
 };
 
+const isNilOrEmptyString = (v) => isNil(v) || v === '';
+
 /*
   Conditional Operators
  */
@@ -112,32 +114,28 @@ const ops: ConditionalOperators = {
   includes: ({value, param}) => includes(value, param),
   // comparison
   greaterThan: ({value, param}) => {
-    // return false if value is nil
-    if (isNil(value)) {
+    if (isNilOrEmptyString(value)) {
       return false;
     }
     value = isNumber(value) ? value : parseFloat(value);
     return value > param;
   },
   lessThan: ({value, param}) => {
-    // return false if value is nil
-    if (isNil(value)) {
+    if (isNilOrEmptyString(value)) {
       return false;
     }
     value = isNumber(value) ? value : parseFloat(value);
     return value < param;
   },
   greaterThanEqual: ({value, param}) => {
-    // return false if value is nil
-    if (isNil(value)) {
+    if (isNilOrEmptyString(value)) {
       return false;
     }
     value = isNumber(value) ? value : parseFloat(value);
     return value >= param;
   },
   lessThanEqual: ({value, param}) => {
-    // return false if value is nil
-    if (isNil(value)) {
+    if (isNilOrEmptyString(value)) {
       return false;
     }
     value = isNumber(value) ? value : parseFloat(value);

--- a/src/conditionalUtils.js
+++ b/src/conditionalUtils.js
@@ -112,20 +112,36 @@ const ops: ConditionalOperators = {
   includes: ({value, param}) => includes(value, param),
   // comparison
   greaterThan: ({value, param}) => {
-    const nvalue = isNil(value) ? 0 : value; // treat nil as 0
-    return isNumber(nvalue) ? nvalue > param : parseFloat(nvalue) > param;
+    // return false if value is nil
+    if (isNil(value)) {
+      return false;
+    }
+    value = isNumber(value) ? value : parseFloat(value);
+    return value > param;
   },
   lessThan: ({value, param}) => {
-    const nvalue = isNil(value) ? 0 : value; // treat nil as 0
-    return isNumber(nvalue) ? nvalue < param : parseFloat(nvalue) < param;
+    // return false if value is nil
+    if (isNil(value)) {
+      return false;
+    }
+    value = isNumber(value) ? value : parseFloat(value);
+    return value < param;
   },
   greaterThanEqual: ({value, param}) => {
-    const nvalue = isNil(value) ? 0 : value; // treat nil as 0
-    return isNumber(nvalue) ? nvalue >= param : parseFloat(nvalue) >= param;
+    // return false if value is nil
+    if (isNil(value)) {
+      return false;
+    }
+    value = isNumber(value) ? value : parseFloat(value);
+    return value >= param;
   },
   lessThanEqual: ({value, param}) => {
-    const nvalue = isNil(value) ? 0 : value; // treat nil as 0
-    return isNumber(nvalue) ? nvalue <= param : parseFloat(nvalue) <= param;
+    // return false if value is nil
+    if (isNil(value)) {
+      return false;
+    }
+    value = isNumber(value) ? value : parseFloat(value);
+    return value <= param;
   },
   // length
   length: ({value, param}) => (isNil(value) ? false : hasIn(value, 'length') ? value.length === param : true),


### PR DESCRIPTION
### Are you submitting a **bug fix** or a **new feature**?
This is a bugfix.

### What I did
<!-- Include here any detailed explanation, related issues, links, etc. -->
Conditional operators for `lessThan`, `greaterThan`, `lessThanEqual`, `greaterThanEqual` were treating nil values (`null`/`undefined`) as `0`.
They operators should treat nil values as invalid input and return `false`.

### How to test
<!-- If your answer is yes to any of these, please make sure to include it in your PR. -->

Is this testable with jest?
Yes, tests have been updated.

Does this need a new example in storybook?
No

Does this need an update to the documentation?
No

### PR Checklist
* [x] Lint and tests passing (`yarn run check`)
* [x] Formatted with prettier (`yarn run format`)
