### PR TITLE
WIP: Revert number comparison change

### DIFF
--- a/__tests__/conditionalUtils.spec.js
+++ b/__tests__/conditionalUtils.spec.js
@@ -232,16 +232,9 @@ describe('evalCond()', () => {
       expect(
         evalCond({
           cond: {questionId: 'foo', lessThan: 5},
-          data: {} // nil will result in false
+          data: {} // nil as 0
         })
-      ).toBe(false);
-
-      expect(
-        evalCond({
-          cond: {questionId: 'foo', lessThan: 5},
-          data: {foo: ''} // empty string will result in false
-        })
-      ).toBe(false);
+      ).toBe(true);
     });
 
     it('should return false if foo is not less than 5', () => {
@@ -262,14 +255,7 @@ describe('evalCond()', () => {
       expect(
         evalCond({
           cond: {questionId: 'foo', lessThan: -5},
-          data: {} // nil will result in false
-        })
-      ).toBe(false);
-
-      expect(
-        evalCond({
-          cond: {questionId: 'foo', lessThan: -5},
-          data: {foo: ''} // empty string will result in false
+          data: {} // nil as 0
         })
       ).toBe(false);
     });
@@ -294,16 +280,9 @@ describe('evalCond()', () => {
       expect(
         evalCond({
           cond: {questionId: 'foo', greaterThan: -5},
-          data: {} // nil will result in false
+          data: {} // nil as 0
         })
-      ).toBe(false);
-
-      expect(
-        evalCond({
-          cond: {questionId: 'foo', greaterThan: -5},
-          data: {foo: ''} // empty string will result in false
-        })
-      ).toBe(false);
+      ).toBe(true);
     });
 
     it('should return false if foo is not greater than 5', () => {
@@ -324,14 +303,7 @@ describe('evalCond()', () => {
       expect(
         evalCond({
           cond: {questionId: 'foo', greaterThan: 5},
-          data: {} // nil will result in false
-        })
-      ).toBe(false);
-
-      expect(
-        evalCond({
-          cond: {questionId: 'foo', greaterThan: 5},
-          data: {foo: ''} // empty string will result in false
+          data: {} // nil as 0
         })
       ).toBe(false);
     });
@@ -356,16 +328,9 @@ describe('evalCond()', () => {
       expect(
         evalCond({
           cond: {questionId: 'foo', lessThanEqual: 5},
-          data: {} // nil will result in false
+          data: {} // nil as 0
         })
-      ).toBe(false);
-
-      expect(
-        evalCond({
-          cond: {questionId: 'foo', lessThanEqual: 5},
-          data: {foo: ''} // empty string will result in false
-        })
-      ).toBe(false);
+      ).toBe(true);
     });
 
     it('should return false if foo is not less than 5', () => {
@@ -386,14 +351,7 @@ describe('evalCond()', () => {
       expect(
         evalCond({
           cond: {questionId: 'foo', lessThanEqual: -5},
-          data: {} // nil will result in false
-        })
-      ).toBe(false);
-
-      expect(
-        evalCond({
-          cond: {questionId: 'foo', lessThanEqual: -5},
-          data: {foo: ''} // empty string will result in false
+          data: {} // nil as 0
         })
       ).toBe(false);
     });
@@ -432,16 +390,9 @@ describe('evalCond()', () => {
       expect(
         evalCond({
           cond: {questionId: 'foo', greaterThanEqual: -5},
-          data: {} // nil will result in false
+          data: {} // nil as 0
         })
-      ).toBe(false);
-
-      expect(
-        evalCond({
-          cond: {questionId: 'foo', greaterThanEqual: -5},
-          data: {foo: ''} // empty string will result in false
-        })
-      ).toBe(false);
+      ).toBe(true);
     });
 
     it('should return false if foo is not greater than 5', () => {
@@ -462,14 +413,7 @@ describe('evalCond()', () => {
       expect(
         evalCond({
           cond: {questionId: 'foo', greaterThanEqual: 5},
-          data: {} // nil will result in false
-        })
-      ).toBe(false);
-
-      expect(
-        evalCond({
-          cond: {questionId: 'foo', greaterThanEqual: 5},
-          data: {foo: ''} // empty string will result in false
+          data: {} // nil as 0
         })
       ).toBe(false);
     });

--- a/src/conditionalUtils.js
+++ b/src/conditionalUtils.js
@@ -33,8 +33,6 @@ const getOperator = (options, key) => {
   return op;
 };
 
-const isNilOrEmptyString = (v) => isNil(v) || v === '';
-
 /*
   Conditional Operators
  */
@@ -114,32 +112,20 @@ const ops: ConditionalOperators = {
   includes: ({value, param}) => includes(value, param),
   // comparison
   greaterThan: ({value, param}) => {
-    if (isNilOrEmptyString(value)) {
-      return false;
-    }
-    value = isNumber(value) ? value : parseFloat(value);
-    return value > param;
+    const nvalue = isNil(value) ? 0 : value; // treat nil as 0
+    return isNumber(nvalue) ? nvalue > param : parseFloat(nvalue) > param;
   },
   lessThan: ({value, param}) => {
-    if (isNilOrEmptyString(value)) {
-      return false;
-    }
-    value = isNumber(value) ? value : parseFloat(value);
-    return value < param;
+    const nvalue = isNil(value) ? 0 : value; // treat nil as 0
+    return isNumber(nvalue) ? nvalue < param : parseFloat(nvalue) < param;
   },
   greaterThanEqual: ({value, param}) => {
-    if (isNilOrEmptyString(value)) {
-      return false;
-    }
-    value = isNumber(value) ? value : parseFloat(value);
-    return value >= param;
+    const nvalue = isNil(value) ? 0 : value; // treat nil as 0
+    return isNumber(nvalue) ? nvalue >= param : parseFloat(nvalue) >= param;
   },
   lessThanEqual: ({value, param}) => {
-    if (isNilOrEmptyString(value)) {
-      return false;
-    }
-    value = isNumber(value) ? value : parseFloat(value);
-    return value <= param;
+    const nvalue = isNil(value) ? 0 : value; // treat nil as 0
+    return isNumber(nvalue) ? nvalue <= param : parseFloat(nvalue) <= param;
   },
   // length
   length: ({value, param}) => (isNil(value) ? false : hasIn(value, 'length') ? value.length === param : true),


### PR DESCRIPTION
This reverts PR #28

## The Issue
The two different use cases for number comparisons:
* `conditionalValid`
	* we want `nil` or empty string to be treated as `0` (returning `true`)
* `conditionalVisible` (and others)
	* we want `nil` or empty string to return `false`

## Thoughts
* when using a conditional operator in validation, if the value is `nil` or empty string, you need to return true. This is so that if the field is optional in the form, it doesn't fail validation just because it hasn't been filled in.

### Are you submitting a **bug fix** or a **new feature**?
Bugfix

### What I did
<!-- Include here any detailed explanation, related issues, links, etc. -->


### How to test
<!-- If your answer is yes to any of these, please make sure to include it in your PR. -->

Is this testable with jest?
Yes

Does this need a new example in storybook?
No

Does this need an update to the documentation?
Yes

### PR Checklist
* [ ] Lint and tests passing (`yarn run check`)
* [ ] Formatted with prettier (`yarn run format`)
