### PR TITLE
Fix context propagation

### DIFF
--- a/src/FormGenerator.js
+++ b/src/FormGenerator.js
@@ -13,8 +13,6 @@ import get from 'lodash/get';
 
 import type {Props, State} from './FormGenerator.types';
 
-const propsToNotUpdateFor = ['_reduxForm'];
-
 class FormGenerator extends Component<Props, State> {
   static propTypes = {
     fields: PropTypes.array.isRequired, // an array of field objects
@@ -52,7 +50,7 @@ class FormGenerator extends Component<Props, State> {
   };
 
   componentWillMount = () => {
-    if (!this.props._reduxForm) {
+    if (!this.props.form) {
       throw new Error('FormGenerator must be inside a component decorated with reduxForm()');
     }
 
@@ -65,24 +63,9 @@ class FormGenerator extends Component<Props, State> {
     }
 
     // clear cache if form has been reset
-    if (this.props._reduxForm.anyTouched && !nextProps._reduxForm.anyTouched) {
+    if (this.props.anyTouched && !nextProps.anyTouched) {
       this.clearCachedValues();
     }
-  }
-
-  shouldComponentUpdate(nextProps: Props) {
-    const nextPropsKeys = Object.keys(nextProps);
-    const thisPropsKeys = Object.keys(this.props);
-
-    return !!(
-      this.props.children ||
-      nextProps.children ||
-      nextPropsKeys.length !== thisPropsKeys.length ||
-      nextPropsKeys.some((prop) => {
-        return !~propsToNotUpdateFor.indexOf(prop) && this.props[prop] !== nextProps[prop];
-      }) ||
-      (this.props._reduxForm.anyTouched && !nextProps._reduxForm.anyTouched)
-    );
   }
 
   updateContext = (props: Props) => {
@@ -92,7 +75,7 @@ class FormGenerator extends Component<Props, State> {
     }
 
     this.setState({
-      ...omit(props, '_reduxForm', 'children'),
+      ...omit(props, 'form', 'anyTouched', 'children'),
       getCachedValue: this.getCachedValue,
       setCachedValue: this.setCachedValue,
       wasGenerated: true,
@@ -117,4 +100,4 @@ class FormGenerator extends Component<Props, State> {
   }
 }
 
-export default consumeReduxFormContext(FormGenerator);
+export default consumeReduxFormContext(FormGenerator, ['form', 'anyTouched']);

--- a/src/GenField.js
+++ b/src/GenField.js
@@ -21,7 +21,7 @@ import type {Props} from './GenField.types';
 import type {FieldOptions} from './types';
 import {getFieldPath} from './validators';
 
-const propsToNotUpdateFor = ['_reduxForm'];
+const propsToNotUpdateFor = [];
 import isDeepEqual from 'react-fast-compare';
 
 import {connect} from 'react-redux';
@@ -229,8 +229,7 @@ const GenFieldWrapped = consumeReduxFormContext(
   consumeGenContext(
     connect(
       (state, props) => {
-        const {_reduxForm, field} = props;
-        const {form, sectionPrefix} = _reduxForm;
+        const {form, sectionPrefix, field} = props;
 
         let calculatedProps = {};
 
@@ -254,12 +253,13 @@ const GenFieldWrapped = consumeReduxFormContext(
         };
       },
       null,
-      // omit _reduxForm and dispatch from props
-      (stateProps, dispatchProps, {_reduxForm, ...ownProps}) => {
+      // omit _reduxForm props and dispatch from props
+      (stateProps, dispatchProps, {form, sectionPrefix, ...ownProps}) => {
         return Object.assign({}, ownProps, stateProps);
       }
     )(GenField)
-  )
+  ),
+  ['form', 'sectionPrefix']
 );
 
 export default GenFieldWrapped;

--- a/src/contextUtils.js
+++ b/src/contextUtils.js
@@ -1,6 +1,8 @@
 // @flow
 import React from 'react';
 import PropTypes from 'prop-types';
+import pick from 'lodash/pick';
+import type {ReduxFormContextType} from './contextUtils.types';
 
 import createContext from 'create-react-context';
 export const GenContext = createContext({wasGenerated: false});
@@ -20,9 +22,12 @@ export const reduxFormContext = {
   _reduxForm: PropTypes.object
 };
 
-export function consumeReduxFormContext(Component: Function) {
-  function ReduxFormContextConsumer(props: mixed, context: mixed) {
-    return <Component {...props} {...context} />;
+export function consumeReduxFormContext(Component: Function, subscriptions?: Array<string>) {
+  function ReduxFormContextConsumer(props: mixed, context: ReduxFormContextType) {
+    const contextProps = {
+      ...(subscriptions ? pick(context._reduxForm, subscriptions) : context)
+    };
+    return <Component {...props} {...contextProps} />;
   }
   ReduxFormContextConsumer.contextTypes = reduxFormContext;
 

--- a/src/contextUtils.types.js
+++ b/src/contextUtils.types.js
@@ -5,3 +5,7 @@ export type GenContextProps = {
   getCachedValue: Function,
   setCachedValue: Function
 };
+
+export type ReduxFormContextType = {
+  _reduxForm: mixed
+};


### PR DESCRIPTION
### Are you submitting a **bug fix** or a **new feature**?
Bug Fix

### What I did
<!-- Include here any detailed explanation, related issues, links, etc. -->
Initially we were using `shouldComponentUpdate` to ignore some props (specifically from the `_reduxForm` context which is coming in as a props) and prevent re-rendering. The side effect is that the old version of React context will not re-render if an ancestor returns false from `shouldComponentUpdate`, and `reduxForm` uses the old context version. The newer version of context using `React.createContext` does not suffer from this issue.

We had `shouldComponentUpdate`s implemented in `<FormGenerator />` and `<GenField />`, and these were returning false and preventing children which listened to the context from re-rendering when they should.

The solution presented here takes an alternate approach. Now we only subscribe to parts of the `_reduxForm` context, and pass those pieces in as individual props. This allows React to take control again to diff props and re-render when necessary. This also allows us to get rid of most of our `shouldComponentUpdate`s.

### How to test
<!-- If your answer is yes to any of these, please make sure to include it in your PR. -->

Is this testable with jest?
Yes

Does this need a new example in storybook?
No

Does this need an update to the documentation?
No

### PR Checklist
* [x] Lint and tests passing (`yarn run check`)
* [x] Formatted with prettier (`yarn run format`)
